### PR TITLE
Add support for contribution metadata

### DIFF
--- a/python/import_exposure_nrml.py
+++ b/python/import_exposure_nrml.py
@@ -149,7 +149,7 @@ def _get_contribution(ex):
 
 def _get_optional_child_text(node, child):
     """
-    The text contained in the specied child node or None if not present
+    The text contained in the specified child node or None if not present
     """
     try:
         return getattr(node, child).text

--- a/python/import_exposure_nrml.py
+++ b/python/import_exposure_nrml.py
@@ -136,16 +136,53 @@ VALUES (%s,%s,%s,%s)
 RETURNING id"""
 
 
+def _get_contribution(ex):
+    """
+    Get contribution node if preset
+    """
+    try:
+        return ex.contribution
+    except Exception:
+        # Ignore exception - optional node
+        return None
+
+
+def _get_model_date(cntr):
+    try:
+        return cntr.model_date.text
+    except Exception:
+        # Ignore exception - optional node
+        return None
+
+
+def _get_model_source(cntr):
+    try:
+        return cntr.model_source.text
+    except Exception:
+        # Ignore exception - optional node
+        return None
+
+
+def _get_notes(cntr):
+    try:
+        return cntr.notes.text
+    except Exception:
+        # Ignore exception - optional node
+        return None
+
+
 def _import_contribution(cursor, ex, model_id):
     """
-    Import contribution meta-data
+    Import contribution meta-data if present
     """
-    if not ex.contribution:
+    cntr = _get_contribution(ex)
+    if cntr is None:
         return
+
     cursor.execute(CONTRIBUTION_QUERY, [
-        ex.contribution.model_source.text,
-        ex.contribution.model_date.text,
-        ex.contribution.notes.text,
+        _get_model_source(cntr),
+        _get_model_date(cntr),
+        _get_notes(cntr),
         model_id])
     return cursor.fetchone()[0]
 

--- a/python/import_exposure_nrml.py
+++ b/python/import_exposure_nrml.py
@@ -142,33 +142,20 @@ def _get_contribution(ex):
     """
     try:
         return ex.contribution
-    except Exception:
+    except AttributeError:
         # Ignore exception - optional node
         return None
 
 
-def _get_model_date(cntr):
+def _get_optional_child_text(node, child):
+    """
+    The text contained in the specied child node or None if not present
+    """
     try:
-        return cntr.model_date.text
-    except Exception:
+        return getattr(node, child).text
+    except AttributeError:
         # Ignore exception - optional node
-        return None
-
-
-def _get_model_source(cntr):
-    try:
-        return cntr.model_source.text
-    except Exception:
-        # Ignore exception - optional node
-        return None
-
-
-def _get_notes(cntr):
-    try:
-        return cntr.notes.text
-    except Exception:
-        # Ignore exception - optional node
-        return None
+        pass
 
 
 def _import_contribution(cursor, ex, model_id):
@@ -180,9 +167,9 @@ def _import_contribution(cursor, ex, model_id):
         return
 
     cursor.execute(CONTRIBUTION_QUERY, [
-        _get_model_source(cntr),
-        _get_model_date(cntr),
-        _get_notes(cntr),
+        _get_optional_child_text(cntr, 'model_source'),
+        _get_optional_child_text(cntr, 'model_date'),
+        _get_optional_child_text(cntr, 'notes'),
         model_id])
     return cursor.fetchone()[0]
 


### PR DESCRIPTION
Addresses issue #6 

Import model source, date and notes from child tags of exposure_model.contribution into the level2.contribution table.  Vice-versa for export.

The metadata in these tags are not used for analysis but may be presented to the use in a data exploration tool and could be useful to help a user select an exposure model.

The contribution tag and all of its child tags are optional.