### PR TITLE
Added support for reading CSV exposure, requires OpenQuake engine == 2.9 (not later)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Python requirements for scripts
 # located in the 'python' folder
 openquake.engine
-django<2
+django==1.11.5
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Python requirements for scripts
 # located in the 'python' folder
-openquake.engine
+openquake.engine==2.9.0
 django==1.11.5
 psycopg2


### PR DESCRIPTION
Added support for reading hybrid NRML/CSV exposure models.
IMPORTANT - requires OpenQuake engine version v2.9 (git checkout v2.9.0) - later versions will not work with Python 2, older versions do not support CSV.