### PR TITLE
Py3comp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ language: python
 jobs:
   include:
   - stage: test
-    env: PYTHON2
-    python: 2.7
-    install:
-     - pip -q install -U flake8
-    script:
-     - flake8 ./python/
-  - stage: test
     env: PYTHON3
     python: 3.6
     install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
      - flake8 ./python/
   - stage: test
     env: POSTGRES
-    python: 2.7
+    python: 3.6
     addons:
       postgresql: 9.6
       apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ jobs:
      - flake8 ./python/
   - stage: test
     env: POSTGRES
-    python: 3.6
     addons:
       postgresql: 9.6
       apt:

--- a/python/database.py
+++ b/python/database.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (c) 2020, GEM Foundation.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.
+# If not, see <https://www.gnu.org/licenses/agpl.html>.
+#
+import psycopg2
+
+
+def db_connections(db_confs):
+    conns = {}
+    for k in db_confs.keys():
+        db_conf = db_confs[k]
+        kwargs={}
+        if 'OPTIONS' in db_conf:
+            if 'sslmode' in db_conf['OPTIONS']:
+                kwargs['sslmode'] = db_conf['OPTIONS']['sslmode']
+
+        conns[k] = psycopg2.connect(user=db_conf['USER'],
+                                    password=db_conf['PASSWORD'],
+                                    host=db_conf['HOST'],
+                                    port=db_conf['PORT'],
+                                    database=db_conf['NAME'],
+                                    **kwargs)
+
+    return conns

--- a/python/database.py
+++ b/python/database.py
@@ -24,7 +24,7 @@ def db_connections(db_confs):
     conns = {}
     for k in db_confs.keys():
         db_conf = db_confs[k]
-        kwargs={}
+        kwargs = {}
         if 'OPTIONS' in db_conf:
             if 'sslmode' in db_conf['OPTIONS']:
                 kwargs['sslmode'] = db_conf['OPTIONS']['sslmode']

--- a/python/db_settings.py.template
+++ b/python/db_settings.py.template
@@ -1,9 +1,5 @@
-DATABASES = {
-    # default entry required by django but not used
-    'default': {
-    },
+db_confs = {
     'geddb': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'ged4all',
         'USER': '<username for export here>',
         'PASSWORD': '<password here>',
@@ -14,7 +10,6 @@ DATABASES = {
         }
     },
     'gedcontrib': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'ged4all',
         'USER': '<username for contributions here>',
         'PASSWORD': '<password here>',

--- a/python/export_exposure_nrml.py
+++ b/python/export_exposure_nrml.py
@@ -25,7 +25,6 @@ population grid.
 """
 import sys
 from xml.etree import ElementTree as etree
-from openquake.baselib.node import tostring
 from database import db_connections
 import db_settings
 
@@ -155,8 +154,9 @@ def _handle_contribution(exm, cursor, model_id):
         contribution = etree.SubElement(exm, 'contribution')
         etree.SubElement(contribution, 'model_source').text = \
             con_dict['model_source']
-        etree.SubElement(contribution, 'model_date').text = \
-            con_dict['model_date']
+        md = con_dict['model_date']
+        if md is not None:
+            etree.SubElement(contribution, 'model_date').text = str(md)
         etree.SubElement(contribution, 'notes').text = \
             con_dict['notes']
         etree.SubElement(contribution, 'license_code').text = \
@@ -242,7 +242,5 @@ if __name__ == '__main__':
 
         verbose_message("Exporting {0}\n".format(xmodel_id))
         sys.stdout.write('<?xml version="1.0" encoding="UTF-8"?>\n')
-        if sys.version_info[0] < 3:
-            sys.stdout.write(tostring(xnrml))
-        else:
-            sys.stdout.write(etree.tostring(xnrml, encoding='unicode', method='xml'))
+        sys.stdout.write(
+            etree.tostring(xnrml, encoding='unicode', method='xml'))

--- a/python/export_exposure_nrml.py
+++ b/python/export_exposure_nrml.py
@@ -245,4 +245,7 @@ if __name__ == '__main__':
 
         verbose_message("Exporting {0}\n".format(xmodel_id))
         sys.stdout.write('<?xml version="1.0" encoding="UTF-8"?>\n')
-        sys.stdout.write(tostring(xnrml))
+        if sys.version_info[0] < 3:
+            sys.stdout.write(tostring(xnrml))
+        else:
+            sys.stdout.write(etree.tostring(xnrml, encoding='unicode', method='xml'))

--- a/python/export_exposure_nrml.py
+++ b/python/export_exposure_nrml.py
@@ -25,14 +25,12 @@ population grid.
 """
 import sys
 from xml.etree import ElementTree as etree
+from database import db_connections
+import db_settings
 
 from openquake.baselib.node import tostring
-from django.db import connections
-from django.conf import settings
-
 
 import db_settings
-settings.configure(DATABASES=db_settings.DATABASES)
 
 VERBOSE = False
 
@@ -224,6 +222,8 @@ def exposure_to_nrml(model_id):
     """
     Return a NRML XML tree for the exposure model with the specified id
     """
+    connections = db_connections(db_settings.db_confs)
+
     with connections['geddb'].cursor() as cursor:
         cursor.execute(MODEL_QUERY, [model_id])
         model_dict = dictfetchone(cursor)

--- a/python/export_exposure_nrml.py
+++ b/python/export_exposure_nrml.py
@@ -25,11 +25,8 @@ population grid.
 """
 import sys
 from xml.etree import ElementTree as etree
-from database import db_connections
-import db_settings
-
 from openquake.baselib.node import tostring
-
+from database import db_connections
 import db_settings
 
 VERBOSE = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Python requirements for scripts
 # located in the 'python' folder
-openquake.engine==2.9.0
-django==1.11.23
+# was openquake.engine==2.9.0
+openquake.engine
 psycopg2


### PR DESCRIPTION
Python 3 compatibility IMPORTANT - Python 2 is no longer supported
Replaced Django dependency with direct use of PostgreSQL via psycopg2 driver
Also adds support for atomic transactions ( fixes #10 )